### PR TITLE
Feature/prisma models

### DIFF
--- a/prisma/migrations/20241110175152_models/migration.sql
+++ b/prisma/migrations/20241110175152_models/migration.sql
@@ -1,0 +1,174 @@
+/*
+  Warnings:
+
+  - Added the required column `birthday` to the `User` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `tel` to the `User` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `travelId` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `user` ADD COLUMN `birthday` VARCHAR(191) NOT NULL,
+    ADD COLUMN `tel` VARCHAR(191) NOT NULL,
+    ADD COLUMN `travelId` INTEGER NOT NULL;
+
+-- CreateTable
+CREATE TABLE `Event` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(191) NOT NULL,
+    `startDate` DATETIME(3) NOT NULL,
+    `endDate` DATETIME(3) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `pointOfInterest` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(191) NOT NULL,
+    `description` VARCHAR(191) NOT NULL,
+    `image` VARCHAR(191) NOT NULL,
+    `locationId` INTEGER NOT NULL,
+    `eventId` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Promotion` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(191) NOT NULL,
+    `description` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Establishment` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(191) NOT NULL,
+    `description` VARCHAR(191) NOT NULL,
+    `Schedule` DATETIME(3) NOT NULL,
+    `eventId` INTEGER NOT NULL,
+    `locationId` INTEGER NOT NULL,
+    `promotionId` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Location` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `street` VARCHAR(191) NOT NULL,
+    `lat` VARCHAR(191) NOT NULL,
+    `lng` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Route` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `data` JSON NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Itinerary` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(191) NOT NULL,
+    `description` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `Travel` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `distance` VARCHAR(191) NOT NULL,
+    `time` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `UserHasItinerary` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `userId` INTEGER NOT NULL,
+    `itineraryId` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `UserHasRoute` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `userId` INTEGER NOT NULL,
+    `routeId` INTEGER NOT NULL,
+    `itineraryId` INTEGER NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `ItineraryHasRoute` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `routeId` INTEGER NOT NULL,
+    `itineraryId` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `ItineraryHasEstablishment` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `itineraryId` INTEGER NOT NULL,
+    `establishmentId` INTEGER NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `User` ADD CONSTRAINT `User_travelId_fkey` FOREIGN KEY (`travelId`) REFERENCES `Travel`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `pointOfInterest` ADD CONSTRAINT `pointOfInterest_locationId_fkey` FOREIGN KEY (`locationId`) REFERENCES `Location`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `pointOfInterest` ADD CONSTRAINT `pointOfInterest_eventId_fkey` FOREIGN KEY (`eventId`) REFERENCES `Event`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Establishment` ADD CONSTRAINT `Establishment_eventId_fkey` FOREIGN KEY (`eventId`) REFERENCES `Event`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Establishment` ADD CONSTRAINT `Establishment_locationId_fkey` FOREIGN KEY (`locationId`) REFERENCES `Location`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Establishment` ADD CONSTRAINT `Establishment_promotionId_fkey` FOREIGN KEY (`promotionId`) REFERENCES `Promotion`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `UserHasItinerary` ADD CONSTRAINT `UserHasItinerary_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `UserHasItinerary` ADD CONSTRAINT `UserHasItinerary_itineraryId_fkey` FOREIGN KEY (`itineraryId`) REFERENCES `Itinerary`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `UserHasRoute` ADD CONSTRAINT `UserHasRoute_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `User`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `UserHasRoute` ADD CONSTRAINT `UserHasRoute_routeId_fkey` FOREIGN KEY (`routeId`) REFERENCES `Route`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `UserHasRoute` ADD CONSTRAINT `UserHasRoute_itineraryId_fkey` FOREIGN KEY (`itineraryId`) REFERENCES `Itinerary`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ItineraryHasRoute` ADD CONSTRAINT `ItineraryHasRoute_routeId_fkey` FOREIGN KEY (`routeId`) REFERENCES `Route`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ItineraryHasRoute` ADD CONSTRAINT `ItineraryHasRoute_itineraryId_fkey` FOREIGN KEY (`itineraryId`) REFERENCES `Itinerary`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ItineraryHasEstablishment` ADD CONSTRAINT `ItineraryHasEstablishment_itineraryId_fkey` FOREIGN KEY (`itineraryId`) REFERENCES `Itinerary`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `ItineraryHasEstablishment` ADD CONSTRAINT `ItineraryHasEstablishment_establishmentId_fkey` FOREIGN KEY (`establishmentId`) REFERENCES `Establishment`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20241110181021_enums/migration.sql
+++ b/prisma/migrations/20241110181021_enums/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - Added the required column `type` to the `Establishment` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `type` to the `Itinerary` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE `establishment` ADD COLUMN `type` ENUM('RESTAURANTE', 'HOTEL', 'SPA', 'CENTRO_COMERCIAL', 'MUSEO', 'BAR_CLUB', 'GALERIA_ARTE', 'CINE', 'PARQUE_TEMATICO', 'PLAYA_RESORT') NOT NULL;
+
+-- AlterTable
+ALTER TABLE `itinerary` ADD COLUMN `type` ENUM('CULTURAL', 'GASTRONOMICO', 'ADVENTURA', 'RELAX', 'FAMILIAR') NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,29 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+//* ENUMS
+
+enum ItineraryType {
+  CULTURAL
+  GASTRONOMICO
+  ADVENTURA
+  RELAX
+  FAMILIAR
+}
+
+enum EstablishmentType {
+  RESTAURANTE
+  HOTEL
+  SPA
+  CENTRO_COMERCIAL
+  MUSEO
+  BAR_CLUB
+  GALERIA_ARTE
+  CINE
+  PARQUE_TEMATICO
+  PLAYA_RESORT
+}
+
 //* USUARIO
 model User {
   id               Int                @id @default(autoincrement())
@@ -84,6 +107,7 @@ model Establishment {
   promotion                 Promotion                   @relation(fields: [promotionId], references: [id])
   promotionId               Int
   ItineraryHasEstablishment ItineraryHasEstablishment[]
+  type                      EstablishmentType
 }
 
 //* UBICACION
@@ -109,7 +133,7 @@ model Itinerary {
   id                        Int                         @id @default(autoincrement())
   name                      String
   description               String
-  // type enum
+  type                      ItineraryType
   UserHasRoute              UserHasRoute[]
   UserHasItinerary          UserHasItinerary[]
   ItineraryHasRoute         ItineraryHasRoute[]
@@ -121,7 +145,6 @@ model Travel {
   id       Int    @id @default(autoincrement())
   distance String
   time     String
-  // type enum
   User     User[]
 }
 


### PR DESCRIPTION
# Description 

Added `TravelType` and `ItineraryType` enums to define distinct travel and itinerary types in the schema.

## Motivation and Context

The existing schema lacked clear differentiation between the types of travel  and itinerary types. Adding these enums in the system. This change will make it easier to filter and categorize both travels and itineraries in the future.

## Screenshots

_No screenshots necessary for this change._

## How Has This Been Tested?

I tested the changes by checking that the new enums were correctly added to the Prisma schema and verifying that data could be inserted with these enum values. I also ensured that the existing data models were unaffected by the changes.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [ ] I have added/updated unit testing
- [ ] This change requires a documentation update
- [ ] Breaking change
